### PR TITLE
Make middleware public

### DIFF
--- a/Sources/VaporRouting/VaporRouting.swift
+++ b/Sources/VaporRouting/VaporRouting.swift
@@ -12,11 +12,17 @@ extension Application {
     _ router: R,
     use closure: @escaping (Request, R.Output) async throws -> AsyncResponseEncodable
   ) where R.Input == URLRequestData {
-    self.middleware.use(RoutingMiddleware(router: router, respond: closure))
+    self.middleware.use(AsyncRoutingMiddleware(router: router, respond: closure))
   }
 }
 
-private struct RoutingMiddleware<Router: Parser>: AsyncMiddleware
+/// Serves requests using a router and response handler.
+///
+/// You will not typically need to interact with this type directly. Instead you should use the
+/// `mount` method on your Vapor application.
+///
+/// See ``VaporRouting`` for more information on usage.
+public struct AsyncRoutingMiddleware<Router: Parser>: AsyncMiddleware
 where Router.Input == URLRequestData {
   let router: Router
   let respond: (Request, Router.Output) async throws -> AsyncResponseEncodable


### PR DESCRIPTION
Right now DocC does not document anything defined on types outside the module, which is currently the entirety of this module. Which makes rendered docs a bit awkward:

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/658/170074256-23dc516b-49f7-487b-bca8-02476f4afd8a.png">

It doesn't hurt to publicize the middleware for better discoverability of documentation for now. In the future we should be able to safely make it private if we want to. It'll still be a bit threadbare, but not as bad.