### PR TITLE
Support ordered dictionaries from URL Routing 0.4.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-url-routing",
         "state": {
           "branch": null,
-          "revision": "80e8a0257ccdd639e31f709954ceca6b690fdc67",
-          "version": "0.3.1"
+          "revision": "f54c4f74e7884f7930560c08387817ce28271770",
+          "version": "0.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-url-routing", from: "0.1.0"),
+    .package(url: "https://github.com/pointfreeco/swift-url-routing", from: "0.4.0"),
   ],
   targets: [
     .target(

--- a/Sources/VaporRouting/URLRequestData+Vapor.Request.swift
+++ b/Sources/VaporRouting/URLRequestData+Vapor.Request.swift
@@ -36,7 +36,7 @@ extension URLRequestData {
       query: components.queryItems?.reduce(into: [:]) { query, item in
         query[item.name, default: []].append(item.value)
       } ?? [:],
-      headers: Dictionary(
+      headers: .init(
         request.headers.map { key, value in
           (
             key,


### PR DESCRIPTION
We had one concrete instance of `Dictionary` that prevents Vapor Routing from compiling with URL Routing 0.4.0, unfortunately. Let's cut a quick release to fix,