### PR TITLE
Collect streaming request bodies

### DIFF
--- a/Sources/VaporRouting/VaporRouting.swift
+++ b/Sources/VaporRouting/VaporRouting.swift
@@ -32,6 +32,11 @@ where Router.Input == URLRequestData {
     chainingTo next: AsyncResponder
   ) async throws -> Response {
 
+    if request.body.data == nil {
+      try await _ = request.body.collect(max: request.application.routes.defaultMaxBodySize.value)
+        .get()
+    }
+
     guard let requestData = URLRequestData(request: request)
     else { return try await next.respond(to: request) }
 


### PR DESCRIPTION
Fixes #22.

Request bodies of a certain size come in streaming and the properties return `nil`. We should check this and perform a check similar to what Vapor's routing tools do internally:

https://github.com/vapor/vapor/blob/1d53c99b6ede0131bb02305f0d62fb2c6c830f3b/Sources/Vapor/Routing/RoutesBuilder%2BMethod.swift#L152